### PR TITLE
Handle multiple env vars defined in one line

### DIFF
--- a/tests/data/travis_success_payload.json
+++ b/tests/data/travis_success_payload.json
@@ -31,7 +31,7 @@
                 "before_script": [],
                 "dist": "precise",
                 "env": [
-                    "TASK=py27"
+                    "TASK=py27 OTHERENVVAR=foobar"
                 ],
                 "python": 3.5,
                 "sudo": false,

--- a/travieso/core.py
+++ b/travieso/core.py
@@ -53,7 +53,7 @@ def get_job_github_state(travis_status, travis_state):
 
 def get_job_task(job):
     for env in job['config']['env']:
-        match = re.search(r'TASK=(.+)', env)
+        match = re.search(r'TASK=(\S+)', env)
         if match:
             return match.group(1)
 


### PR DESCRIPTION
Multiple env vars in a single line is valid .travis.yml syntax.
This patch ensures the match TASK is on non-whitespace chars only

Closes #8 
