### PR TITLE
Use head commit instead of merge commit for PRs

### DIFF
--- a/travieso/views.py
+++ b/travieso/views.py
@@ -10,8 +10,12 @@ blueprint = Blueprint('travis', __name__)
 @blueprint.route('/notifications', methods=['POST'])
 @authorize_travis
 def handle_notification(payload):
+    head_commit = payload['head_commit']
     for job in payload['matrix']:
         state = get_job_github_state(job['status'], job['state'])
+        # For pull requests, the commit_sha we get back is that of the merge_commit_sha.
+        # We don't want this!
+        commit = head_commit if payload['type'] == 'pull_request' else job['commit']
         commit = job['commit']
         job_id = job['id']
         job_task = get_job_task(job)

--- a/travieso/views.py
+++ b/travieso/views.py
@@ -16,7 +16,6 @@ def handle_notification(payload):
         # For pull requests, the commit_sha we get back is that of the merge_commit_sha.
         # We don't want this!
         commit = head_commit if payload['type'] == 'pull_request' else job['commit']
-        commit = job['commit']
         job_id = job['id']
         job_task = get_job_task(job)
 


### PR DESCRIPTION
When Travis sends webhook notifications for PRs, `job['commit']` yields the merge sha instead of the head commit of the branch for the PR. Instead, `payload['head_commit']` should be used.

I've applied this fix in my local version, and it resolves the problem, however I haven't tested sufficiently to know whether you can get away with just always using `payload['head_commit']` instead of `job['commit']`, rather than in the one cases that my patch considers. Probs can I guess.

As for tests, I haven't submitted a testcase (not sure how one would work for this), but to prove my point, you can see that Travisio hasn't reported statuses back to Github for this PR!

Closes #10 
